### PR TITLE
fix: image mime type to PNG

### DIFF
--- a/test-utils/mock-responses/image-response.json
+++ b/test-utils/mock-responses/image-response.json
@@ -2,11 +2,11 @@
   "predictions": [
     {
       "bytesBase64Encoded": "test-image-data",
-      "mimeType": "image/jpeg"
+      "mimeType": "image/png"
     },
     {
       "bytesBase64Encoded": "test-image-data",
-      "mimeType": "image/jpeg"
+      "mimeType": "image/png"
     }
   ]
 }


### PR DESCRIPTION
was testing some with a paid tier and realised the test mime was wrong. 